### PR TITLE
Fixed working with encodings

### DIFF
--- a/src/DS.DfmParser.pas
+++ b/src/DS.DfmParser.pas
@@ -285,8 +285,8 @@ begin
   Objects.Clear;
   DfmObject := nil;
 
-  RegExObject := TRegEx.Create('^(\w+) (?:([\w\däöü_]+): )?([\w\d_]+)(?: \[(\d+)\])?$', [roIgnoreCase]);
-  RegExProperty := TRegEx.Create('^([\w\d_\.]+) =(?:(?: (.*)$)|$)', [roIgnoreCase]);
+  RegExObject := TRegEx.Create('^(\w+) (?:([\p{L}\d_]+): )?([\p{L}\d_]+)(?: \[(\d+)\])?$', [roIgnoreCase]);
+  RegExProperty := TRegEx.Create('^([\p{L}\d_\.]+) =(?:(?: (.*)$)|$)', [roIgnoreCase]);
   Lines := TStringList.Create;
   try
     Lines.Delimiter := LF;


### PR DESCRIPTION
1) The name of an object or property can be in different languages ​​(in my case it was Cyrillic), so I used /p{L} to match a letter from any language
2) When a unicode symbol is used for an object name in dfm, the file encoding automatically changes to utf8 with boom. Therefore, it is necessary to save the file in the original encoding, and not in the default encoding (in my case, the utf8 file was saved as ansi). The encoding property was made open for manual encoding specification in case of loading dfm contents from a string, as well as when adding a property or object with a unicode name